### PR TITLE
Lag en generisk My Maps-shortcode

### DIFF
--- a/content/reisekart.md
+++ b/content/reisekart.md
@@ -11,7 +11,7 @@ For å visualisere mine flyreiser rundt om kring i verden, har jeg laget et kart
 
 {{% /ingress %}}
 
-{{< flykart >}}
+{{< mymaps 1-WOIi8QVWmtiSyloYHJxDPYAIR0 >}}
 
 ### Bidrag, spørsmål eller forespørsler?
 

--- a/content/timtraveller.md
+++ b/content/timtraveller.md
@@ -28,7 +28,7 @@ Speyside Way her). - Grenser (morsomme og rare landegrenser). - Alt annet av byg
 monumenter. - [PeakQuest - Climbing The Highest Point In All 48 Counties of
 England](https://www.youtube.com/watch?v=rNkbRjb7YDY&t=25s)
 
-{{< timtraveller >}}
+{{< mymaps 18Avv8ENKUFllJieGN568CSVIYZr6oIcb >}}
 
 ## Eksludert fra kartet
 

--- a/layouts/shortcodes/flykart.html
+++ b/layouts/shortcodes/flykart.html
@@ -1,1 +1,0 @@
-<iframe src="https://www.google.com/maps/d/embed?mid=1-WOIi8QVWmtiSyloYHJxDPYAIR0" width="640" height="480"></iframe>

--- a/layouts/shortcodes/mymaps.html
+++ b/layouts/shortcodes/mymaps.html
@@ -1,0 +1,6 @@
+<iframe
+  src="https://www.google.com/maps/d/embed?mid={{ .Get 0 }}"
+  width="640"
+  height="480"
+>
+</iframe>

--- a/layouts/shortcodes/mymaps.html
+++ b/layouts/shortcodes/mymaps.html
@@ -1,6 +1,7 @@
-<iframe
-  src="https://www.google.com/maps/d/embed?mid={{ .Get 0 }}"
-  width="640"
-  height="480"
->
-</iframe>
+<div class="embed-responsive embed-responsive-4by3">
+  <iframe
+    class="embed-responsive-item"
+    src="https://www.google.com/maps/d/embed?mid={{ .Get 0 }}"
+  >
+  </iframe>
+</div>

--- a/layouts/shortcodes/timtraveller.html
+++ b/layouts/shortcodes/timtraveller.html
@@ -1,1 +1,0 @@
-<iframe src="https://www.google.com/maps/d/embed?mid=18Avv8ENKUFllJieGN568CSVIYZr6oIcb" width="640" height="480"></iframe>


### PR DESCRIPTION
De to shortcodene "timtraveller" og "flykart" var identiske bortsett fra kart-ID-en i URL-en. Ved å generalisere dem til en "Google My Maps"-shortcode som tar en ID som parameter, kan man lage flere My Maps-elementer i nye sider uten å trenge å lage en ny HTML-fil i shortcodes-mappa, og hvis man vil gjøre en endring som påvirker alle My Maps-elementene er det tilstrekkelig å endre på én fil.

Iframene hadde hardkodet bredde og høyde, og gikk over bredden på skjermen på små skjermer. Nå brukes Bootstraps CSS-klasser for embeddede ting: https://getbootstrap.com/docs/4.5/utilities/embed/